### PR TITLE
Add plone.api as a dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(name='adi.trash',
       include_package_data=True,
       zip_safe=False,
       install_requires=[
+          'plone.api',
           'setuptools',
       ],
       entry_points="""


### PR DESCRIPTION
plone.api isn't a direct dependency of Plone so it needs to be added here since it's used in https://github.com/ida/adi.trash/blob/740c00fa95fce73677faef316f4a982b6da4d5e9/adi/trash/browser/browser.py#L1

It's a good practice to do the same to all the other dependencies, but this can be done in another PR. This fix here is being made because in a Vanilla Plone install without plone.api, adding adi.trash to `eggs` breaks the buildout. For this reason, we suggest a new release right after merging this PR.